### PR TITLE
Add certificate validation option

### DIFF
--- a/cas-maestro.php
+++ b/cas-maestro.php
@@ -69,6 +69,7 @@ class CAS_Maestro {
 			    'server_hostname' => 'yourschool.edu',
 			    'server_port' => '443',
 			    'server_path' => '',
+				'cert_path' => '',
 			    'e-mail_registration' => 1,
 			    'global_sender'=>get_bloginfo('admin_email'),
 			    'full_name' => '',
@@ -140,10 +141,11 @@ class CAS_Maestro {
 				// function added in phpCAS v. 0.6.0
 				// checking for static method existance is frustrating in php4
 				$phpCas = new phpCas();
-				if (method_exists($phpCas, 'setNoCasServerValidation'))
+				if (method_exists($phpCas, 'setCasServerCACert') && $this->settings['cert_path'])
+					phpCAS::setCasServerCACert($this->settings['cert_path']);
+				elseif (method_exists($phpCas, 'setNoCasServerValidation'))
 					phpCAS::setNoCasServerValidation();
 				unset($phpCas);
-				// if you want to set a cert, replace the above few lines	
 
 				if(defined('CAS_MAESTRO_DEBUG_ON') && CAS_MAESTRO_DEBUG_ON == true)
 					phpCAS::setDebug(CAS_MAESTRO_PLUGIN_PATH . 'debug.log');
@@ -584,6 +586,7 @@ class CAS_Maestro {
 				'server_hostname' => $_POST['server_hostname'],
 				'server_port' => $_POST['server_port'],
 				'server_path' => $_POST['server_path'],
+				'cert_path'   => $_POST['cert_path'],
 				//LDAP Settings
 		    	'ldap_protocol'=>$_POST['ldap_protocol'],
 		    	'ldap_server'=>$_POST['ldap_server'],

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,9 @@ By default, the capability is `edit_posts`.
 
 == Changelog ==
 
+= 1.1.4 =
+* Added option for certificate validation
+
 = 1.1.3 =
 * Users with 'edit_posts' capability can now edit only the authorized users (this can be changed using a filter - see FAQ)
 

--- a/views/metaboxes/general.php
+++ b/views/metaboxes/general.php
@@ -31,6 +31,21 @@
                 </tr>
             </tbody>
         </table>
+        <h2><?php _e('Certificate validation','CAS_Maestro'); ?></h2>
+        <fieldset class="options">
+            <p><?php _e("Path to certificat for validation of the legitimacy of the cas server. Recommended for production use.", 'CAS_Maestro'); ?></p>
+            <p class="grey_text"><?php _e("No certificate validation will be used if path is left blank", 'CAS_Maestro'); ?></p>
+            <p class="grey_text"><?php _e("", 'CAS_Maestro'); ?></p>
+            <table width="700px" cellspacing="2" cellpadding="5" class="editform">
+                <tbody>
+                <tr>
+                    <th width="150px" scope="row"><label for="cert_path_inp"><?php _e('Cert path', 'CAS_Maestro'); ?></label></th>
+                    <td>
+                        <input type="text" name="cert_path" id="cert_path_inp" value="<?php echo $this->settings['cert_path']; ?>" size="25" />
+                    </td>
+                </tr>
+                </tbody>
+            </table>
         <div class='availability_result' id="username_availability_result"></div>
         <h2><?php _e('Menu localization', 'CAS_Maestro'); ?></h2>
         <p>


### PR DESCRIPTION
This adds an option on the settings page to enter a path to the CAS certificate for validation. Bypassing cert validation is not recommended for production use so this seems like a necessary option. If a path is entered, it is passed to `phpCAS::setCasServerCACert()`, otherwise  `phpCAS::setNoCasServerValidation()` is used.
